### PR TITLE
test: use concise WebEnvironment.RANDOM_PORT in @SpringBootTest

### DIFF
--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreIntegrationTests.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -33,8 +34,7 @@ import org.springframework.stereotype.Service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @AutoConfigureTestRestTemplate
-@SpringBootTest(classes = AgentCoreIntegrationTests.TestApp.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = AgentCoreIntegrationTests.TestApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 class AgentCoreIntegrationTests {
 
 	@LocalServerPort

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndContextIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndContextIntegrationTests.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -38,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @AutoConfigureTestRestTemplate
 @SpringBootTest(classes = EndToEndContextIntegrationTests.ContextTestApp.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 class EndToEndContextIntegrationTests {
 
 	@LocalServerPort

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndJsonIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndJsonIntegrationTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -31,8 +32,7 @@ import org.springframework.stereotype.Service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @AutoConfigureTestRestTemplate
-@SpringBootTest(classes = EndToEndJsonIntegrationTests.TestApp.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = EndToEndJsonIntegrationTests.TestApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 class EndToEndJsonIntegrationTests {
 
 	@LocalServerPort

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndStringIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndStringIntegrationTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -31,8 +32,7 @@ import org.springframework.stereotype.Service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @AutoConfigureTestRestTemplate
-@SpringBootTest(classes = EndToEndStringIntegrationTests.TestApp.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = EndToEndStringIntegrationTests.TestApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 class EndToEndStringIntegrationTests {
 
 	@LocalServerPort

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndWebFluxIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndWebFluxIntegrationTests.java
@@ -30,6 +30,7 @@ import reactor.test.StepVerifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -41,7 +42,7 @@ import org.springframework.web.server.ResponseStatusException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = EndToEndWebFluxIntegrationTests.FluxTestApp.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 @Disabled
 class EndToEndWebFluxIntegrationTests {
 

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterDisabledTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterDisabledTests.java
@@ -21,6 +21,7 @@ import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,7 @@ import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
 		properties = { "agentcore.throttle.invocations-limit=0", "agentcore.throttle.ping-limit=0" })
 class RateLimitingFilterDisabledTests {
 

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterTests.java
@@ -21,6 +21,7 @@ import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
 		properties = { "agentcore.throttle.invocations-limit=2", "agentcore.throttle.ping-limit=3" })
 class RateLimitingFilterTests {
 


### PR DESCRIPTION
spring-javaformat 0.0.48 adds the SpringAnnotationAttributeConciseValue checkstyle rule, which rejects the verbose
SpringBootTest.WebEnvironment.RANDOM_PORT form. Import the nested WebEnvironment enum and use WebEnvironment.RANDOM_PORT so the sources conform once the spring-javaformat bump lands. Valid under 0.0.47 too, so main stays green in the meantime.