### PR TITLE
test: make browser form-fill test deterministic

### DIFF
--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/LocalBrowserClientTests.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/LocalBrowserClientTests.java
@@ -94,7 +94,10 @@ class LocalBrowserClientTests {
 	@Order(4)
 	@DisplayName("Should fill form field")
 	void shouldFillFormField() {
-		String result = client.fill("https://duckduckgo.com", "input[name='q']", "test query");
+		// Use a self-contained data: URL so the test does not depend on a live
+		// third-party page whose markup or bot protection can change and flake.
+		String page = "data:text/html,<input name='q'>";
+		String result = client.fill(page, "input[name='q']", "test query");
 
 		assertThat(result).containsIgnoringCase("filled");
 	}


### PR DESCRIPTION
LocalBrowserClientTests.shouldFillFormField drove a real browser to https://duckduckgo.com and waited for input[name='q']. That page is JS-rendered and bot-gated, so the locator often never appears and the test times out after 30s (Playwright TimeoutError) - flaky in CI.

Point the test at a self-contained data: URL carrying the input element instead, so it verifies the fill operation without depending on a live third-party page. Other cases use the stable https://example.com and are left unchanged.